### PR TITLE
Add using Jellyfin Web from Resources, no symlink needed

### DIFF
--- a/Jellyfin Server/AppDelegate.swift
+++ b/Jellyfin Server/AppDelegate.swift
@@ -39,9 +39,10 @@ var task = Process()
         }
         
         let path = Bundle.main.path(forAuxiliaryExecutable: "jellyfin")
-
+        let webui = Bundle.main.resourceURL!.appendingPathComponent("jellyfin-web").path
+        
         task.launchPath = path
-        //task.arguments = ["--noautorunwebapp"]
+        task.arguments = ["--webdir", webui]
         
         do {
             try  task.run()


### PR DESCRIPTION
When building, moves jellyfin-web location to the resources folder, and uses that on startup.
Removes the need to make a symlink in `Contents/MacOS/`.