### PR TITLE
Update Documentation and Fix Authors file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,2 @@
-Original syncthing-macos authors:
-* Jerry Jacobs ([@xor-gate](https://github.com/xor-gate))
-* Victor Babenko ([@virusman](https://github.com/virusman))
-* Jakob Borg ([@calmh](https://github.com/calmh))
-
 For jellyfin-server-macos:
 * Anthony Lavado ([@anthonylavad](https://github.com/anthonylavado))

--- a/Jellyfin Server/AppDelegate.swift
+++ b/Jellyfin Server/AppDelegate.swift
@@ -5,6 +5,11 @@
 //  Created by Anthony Lavado on 2019-06-26.
 //  Copyright © 2019 Anthony Lavado. All rights reserved.
 //
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 
 import Cocoa
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,83 @@
 <h1 align="center">Jellyfin for macOS</h1>
 <h3 align="center">Part of the <a href="https://jellyfin.media">Jellyfin Project</a></h3>
 
+---
+
+<p align="center">
+<img alt="Logo Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
+<br/>
+<br/>
+<a href="https://github.com/jellyfin/jellyfin-server-macos/blob/master/LICENSE">
+<img alt="MPL 2.0 License" src="https://img.shields.io/github/license/jellyfin/jellyfin-server-macos.svg"/>
+</a>
+<a href="https://opencollective.com/jellyfin">
+<img alt="Donate" src="https://img.shields.io/opencollective/all/jellyfin.svg?label=backers"/>
+</a>
+<a href="https://features.jellyfin.org">
+<img alt="Submit Feature Requests" src="https://img.shields.io/badge/fider-vote%20on%20features-success.svg"/>
+</a>
+<a href="https://matrix.to/#/+jellyfin:matrix.org">
+<img alt="Chat on Matrix" src="https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix"/>
+</a>
+<a href="https://www.reddit.com/r/jellyfin">
+<img alt="Join our Subreddit" src="https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg"/>
+</a>
+<a href="https://github.com/jellyfin/jellyfin-server-macos/commits/master.atom">
+<img alt="Commits RSS Feed" src="https://img.shields.io/badge/rss-commits-ffa500?logo=rss" />
+</a>
+</p>
+
+---
+
 <p align="center">
 Jellyfin for macOS is a launcher/wrapper built in Swift and Objective-C.
 </p>
+<br/>
 
-## Build Process
+# Getting Started
+Are you looking to just run and setup Jellyfin on your macOS machine? Go to https://jellyfin.org/downloads and get the macOS stable release.
 
-### Getting Started
+Do you want to build Jellyfin's menu bar app/launcher for yourself? Read on!
 
-The Build Process instructions need to be updated, and will be coming soon.
-<!--1. Clone or download this repository.
+---
+
+## Compiling the Menu App
+### Requirements
+* [Xcode for macOS](https://developer.apple.com/xcode/)
+
+### Steps
+1. Clone or download this repository.
    ```sh
    git clone https://github.com/jellyfin/jellyfin-server-macos.git
    ```
-2. Download Jellyfin, and extract it. Rename the folder to `jellyfin` and put it inside the resources folder.
+2. Open `Jellyfin Server.xcodeproj` with Xcode. Update version number and build.
+3. Archive the app to a local directory.
 
-3. Download the correct version of FFmpeg. Extract it, and place `ffmpeg` and `ffprobe` in the root of `jellyfin-mac-app-resources`.
+### Usage
+The Menu app is designed to do three things:
+1. Start and Stop a pre-packaged Jellyfin in the background
+2. Open the Web UI
+3. Open the Log Folder
+4. Ensure that the Jellyfin binary is pointed to the packaged version of the web UI
+5. Ensure that a cache folder exists before launching the server
 
-4. Open `Server.xcodeproj` with Xcode, and build.-->
 
+## Building the Full Package
+### Requirements
+* The compiled menu bar app from above
+* The latest [Jellyfin macOS Combined](https://repo.jellyfin.org/releases/server/macos/versions/stable/combined/) package
 
+If you choose to build Jellyfin server on your own, you will also require:
+* [FFmpeg](https://evermeet.cx/ffmpeg/) for macOS, or equivalent FFmpeg/FFprobe 4.4+.
 
-
-
-### FFmpeg Download
-
-It's recommended to use a static macOS build of FFmpeg, such as [Zeranoe's Builds](https://ffmpeg.zeranoe.com/builds/macos64/static/).
-
-At the time of writing, please use [ffmpeg-4.2.2-macos64-static.zip](https://ffmpeg.zeranoe.com/builds/macos64/static/ffmpeg-4.2.2-macos64-static.zip).
-
+### Steps
+1. Ensure that a complete copy of Jellyfin Server is available in a folder. If using the combined package from above, proceed to the next step.
+    * If you are building Jellyfin from source, place a copy of `ffmpeg` in the same folder as the server binary. You need to add `ffmpeg` and `ffprobe` alongside `jellyfin`. Ensure that you also build `jellyfin-web`.
+    * If using a packaged version, take the `jellyfin-web` folder out of the folder with the server in it.
+2. Locate the .app that was built above. Right/Ctrl Click it and choose "Show Package Contents".
+3. Go inside the folder `Contents`, then `MacOS`. Place the Jellyfin server and FFmpeg files here. Make sure they are not in a subfolder of their own.
+4. Go up one level, and go to the `Resources` folder. Place the `jellyfin-web` folder here. The folder name must match.
+5. (Optional) If you want to sign the .app for distribution, see the [Deployment Instructions](https://github.com/jellyfin/jellyfin-server-macos/tree/master/deployment).
 
 ## Troubleshooting
 
@@ -39,10 +87,10 @@ Please review the error inside Xcode. If a build failed, it is likely because th
 
 ### The project built, but Jellyfin didn't launch. Xcode shows an error.
 
-This is because Jellyfin needs to be placed in the app bundle so it can be launched. This is currently a manual process, which will be automated for future use.
+This is because Jellyfin needs to be placed in the app bundle so it can be launched. This is currently a manual process, which can be scripted for convenience.
 
-Does the console show a `Failed to bind to address` message? You may already have a copy of Jellyfin running on your computer. This can happen if you did not shutdown a separate Jellyfin install, or if you clicked on "Stop" inside Xcode. Use Activity Monitor to find and quit any open Jellyfin process.
+Does the console show a `Failed to bind to address` message? You may already have a copy of Jellyfin running on your computer. This can happen if you did not shutdown a separate Jellyfin install, or if you clicked on "Stop" inside Xcode while running/debugging. Use Activity Monitor to find and quit any open Jellyfin process.
 
 ### The project built, but Jellyfin didn't launch. There are no errors I can see.
 
-This wrapper may launch the Web UI too quickly. This will eventually be configurable. In the meanwhile, you can use the Jellyfin icon in the menu bar to launch the Web UI again.
+You must manually open the web UI by clicking on the icon in the menu bar first.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -4,20 +4,22 @@
 
 In order to distribute a notarized app that complies with GateKeeper, you must follow these steps. Using Developer ID requires a paid Apple Developer Program membership.
 
-### Set Capabilities
+## Set Capabilities
 To notarize an app, it must be using the Hardened Runtime features of Xcode.
 These should already be set in the project, but for reference, you must enable these capabilities:
 
 * [x] **Hardened Runtime**
     * [x] Allow Execution of JIT-compiled Code
     * [x] Allow Unsigned Executable Memory
+    * [x] Allow DYLD Environment Variables
     * [x] Disable Library Validation
+  
+These are also listed in the `Jellyfin_Server.entitlements` file in this directory. 
 
-### Codesign Resources
-To prepare for distribution, first create an archive for distribution. Once you have the `.app`, you must sign it.
+## Codesign Resources
+To prepare for distribution, first create an archive for distribution. All items in `Contents/Frameworks` and `Contents/MacOS` must be signed. Then you can sign the app as a whole.
 
-Here is an example set of commands:
-
+An example signing command looks like this:
 ```bash
 codesign --force --options runtime --sign "Developer ID Application: COMPANYNAME" ./Jellyfin.app
 ```
@@ -27,8 +29,34 @@ If you are an individual developer, you can place your name in the same spot as 
 codesign --force --options runtime --sign "Developer ID Application: Anthony Lavado" ./Jellyfin.app
 ```
 
-### Signing Order
+Here is an example shell script, using the signing identity like above:
+
+```bash
+# Setup variables. Ensure that the .app name is correct, and that both the .app
+# and entitlements files are at the correct path.
+APP_NAME="Jellyfin.app"
+ENTITLEMENTS="Jellyfin_Server.entitlements"
+SIGNING_IDENTITY="\"Developer ID Application: Anthony Lavado\""
+
+# Iterate through contents that should be signed, and sign them
+find "$APP_NAME/Contents/MacOS" -type f | while read fname; do
+    echo "[INFO] Signing $fname"
+    codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign $SIGNING_IDENTITY "$fname"
+done
+
+find "$APP_NAME/Contents/Frameworks" -type f | while read fname; do
+    echo "[INFO] Signing $fname"
+    codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign $SIGNING_IDENTITY "$fname"
+done
+
+echo "[INFO] Signing app file..."
+
+codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign $SIGNING_IDENTITY "$APP_NAME"
+```
+
 After you sign the app, it is important to get it notarized by Apple so that it runs without issues on an end user's machine. If you decide to create a DMG, you must wait until you first get the app notarized, then package it in the DMG. Once you have your final DMG, you must submit it to Apple for notarization. Without this step, users will get warning messages when trying to mount the DMG.
+
+If you want Gatekeeper validation to pass on an offline Mac, you must staple the ticket to the DMG.
 
 ### DMG Considerations
 If you opt to create a DMG for the app, you can use the wonderful https://github.com/sindresorhus/create-dmg.git.
@@ -37,3 +65,6 @@ If you opt to create a DMG for the app, you can use the wonderful https://github
 For actual steps on notarizing, I recommend two articles.
 * Scripting OS X - Notarize a Command Line Tool - [Live Link](https://scriptingosx.com/2019/09/notarize-a-command-line-tool/) / [archive.org](https://web.archive.org/web/20191019023702/https://scriptingosx.com/2019/09/notarize-a-command-line-tool/)
 * Apple Developer - Notarizing Your App Before Distribution - [Live Link](https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution) / [archive.org](https://web.archive.org/web/20191014165810/https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution)
+
+## Practical Example
+The current package and signing script can be viewed as a [GitHub Gist](https://gist.github.com/anthonylavado/e51db1e67e5c4ae047877ab4b2261cd3).


### PR DESCRIPTION
Finally adds all the documentation on how to build and sign the app yourself.

Removes the syncthing authors from the AUTHORS file, as their code isn't used anymore. I reverted back to my own code a long time ago and never fixed up this file.

Closes #33.