### PR TITLE
Fix for upcoming 10.9 release

### DIFF
--- a/Jellyfin Server.xcodeproj/project.pbxproj
+++ b/Jellyfin Server.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -351,7 +351,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = Jellyfin.Server;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -375,7 +375,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = Jellyfin.Server;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Jellyfin Server/AlertWindow/AlertViewController.storyboard
+++ b/Jellyfin Server/AlertWindow/AlertViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,15 +16,15 @@
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fdY-Da-lII">
                                 <rect key="frame" x="111" y="3" width="134" height="32"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="120" id="r62-wU-Ttb"/>
-                                    <constraint firstAttribute="height" constant="20" id="scZ-eY-Uyg"/>
-                                </constraints>
                                 <buttonCell key="cell" type="push" title="Exit" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Png-uI-fVN">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <color key="bezelColor" name="linkColor" catalog="System" colorSpace="catalog"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="120" id="r62-wU-Ttb"/>
+                                    <constraint firstAttribute="height" constant="20" id="scZ-eY-Uyg"/>
+                                </constraints>
                                 <connections>
                                     <action selector="exitSelected:" target="bU7-R8-ocO" id="fhS-Ze-Fpf"/>
                                 </connections>

--- a/Jellyfin Server/AppDelegate.swift
+++ b/Jellyfin Server/AppDelegate.swift
@@ -60,15 +60,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func startJellyfinTask() {
         let jellyfinPath = Bundle.main.path(forAuxiliaryExecutable: "jellyfin")
+        let ffmpegPath = Bundle.main.path(forAuxiliaryExecutable: "ffmpeg")
         let webUIPath = Bundle.main.resourceURL!.appendingPathComponent("jellyfin-web").path
 
         guard let jellyfinPath = jellyfinPath else {
             present(alert: "Jellyfin Server was unable to start underlying jellyfin task.")
             return
         }
+        
+        guard let ffmpegPath = ffmpegPath else {
+            present(alert: "Jellyfin Server was unable to find bundled ffmpeg.")
+            return
+        }
 
         jellyfinProcess.launchPath = jellyfinPath
-        jellyfinProcess.arguments = ["--webdir", webUIPath, "--cache", applicationSupportJellyfinFolder.path]
+        jellyfinProcess.arguments = ["--webdir", webUIPath, "--ffmpeg", ffmpegPath, "--datadir", applicationSupportJellyfinFolder.path]
 
         do {
             try jellyfinProcess.run()

--- a/Jellyfin Server/Base.lproj/Main.storyboard
+++ b/Jellyfin Server/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -673,7 +674,7 @@
                         <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
                     </connections>
                 </application>
-                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Server" customModuleProvider="target"/>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Jellyfin_Server" customModuleProvider="target"/>
                 <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Jellyfin Server/Info.plist
+++ b/Jellyfin Server/Info.plist
@@ -27,7 +27,7 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2022 Jellyfin Contributors</string>
+	<string>Copyright © 2024 Jellyfin Contributors</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/Jellyfin Server/PreferencesWindow/PreferencesViewController.storyboard
+++ b/Jellyfin Server/PreferencesWindow/PreferencesViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -36,7 +36,7 @@
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a23-zM-ylI">
                                 <rect key="frame" x="-2" y="10" width="354" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Copyright © 2022 Jellyfin" id="5VS-Kj-kIo">
+                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Copyright © 2024 Jellyfin" id="5VS-Kj-kIo">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -54,44 +54,44 @@
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gxh-eI-cDG">
                                 <rect key="frame" x="108" y="111" width="134" height="32"/>
+                                <buttonCell key="cell" type="push" title="Launch Web UI" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="wE7-Nw-pDc">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="8x3-gy-6H5"/>
                                     <constraint firstAttribute="width" constant="120" id="Ahg-po-3td"/>
                                     <constraint firstAttribute="height" constant="20" id="xQy-q3-kdD"/>
                                 </constraints>
-                                <buttonCell key="cell" type="push" title="Launch Web UI" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="wE7-Nw-pDc">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
                                 <connections>
                                     <action selector="launchWebUISelected:" target="bU7-R8-ocO" id="Y1q-ze-oTU"/>
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hE0-YK-gRX">
                                 <rect key="frame" x="108" y="81" width="134" height="32"/>
+                                <buttonCell key="cell" type="push" title="Show Logs" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6WI-yj-06V">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="3kk-Pb-tWB"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="QAT-4c-DkD"/>
                                     <constraint firstAttribute="width" constant="120" id="z2X-7N-gUG"/>
                                 </constraints>
-                                <buttonCell key="cell" type="push" title="Show Logs" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6WI-yj-06V">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
                                 <connections>
                                     <action selector="showLogsSelected:" target="bU7-R8-ocO" id="9jx-gg-Oqp"/>
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3SL-fH-pl4">
                                 <rect key="frame" x="108" y="51" width="134" height="32"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="20" id="DNG-Ny-2hn"/>
-                                    <constraint firstAttribute="width" constant="120" id="LPR-XR-Lo7"/>
-                                </constraints>
                                 <buttonCell key="cell" type="push" title="About" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Em3-6n-hE4">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="DNG-Ny-2hn"/>
+                                    <constraint firstAttribute="width" constant="120" id="LPR-XR-Lo7"/>
+                                </constraints>
                                 <connections>
                                     <action selector="aboutSelected:" target="bU7-R8-ocO" id="EcU-RU-LdB"/>
                                 </connections>


### PR DESCRIPTION
This PR:

- Targets macOS 12 because dotnet 8 officially requires this version to run. This will allow us to use new APIs in the future. Our FFmpeg also relies on modern OS APIs to perform certain hardware acceleration operations.
- Changes the banner to show "2024."
- Fixes the command line for 10.9. It now specifies the ffmpeg path using the `--ffmpeg` CLI parameter. This would make it impossible for our users to specify a custom ffmpeg binary, and if that is a supported use case, then an additional setting for this in this app is required.