### PR TITLE
Fix migration logic

### DIFF
--- a/Jellyfin Server/ActionManager.swift
+++ b/Jellyfin Server/ActionManager.swift
@@ -15,7 +15,7 @@ enum ActionManager {
     }
 
     static func showLogs() {
-        let logFolder = applicationSupportJellyfinFolder.appendingPathComponent("/log")
+        let logFolder = directoryExists(path: localShareJellyfinFolder.path) ? localShareJellyfinFolder.appendingPathComponent("/log") : applicationSupportJellyfinFolder.appendingPathComponent("/log")
         NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: logFolder.path)
     }
 

--- a/Jellyfin Server/AppDelegate.swift
+++ b/Jellyfin Server/AppDelegate.swift
@@ -29,31 +29,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func createAppFolder() {
-        // Old contents were stored in ~/.local/share
-        // Move to ~/Library/Application Support/Jellyfin
-        if directoryExists(path: localShareJellyfinFolder.path) {
-            do {
-                let contents = try FileManager.default.contentsOfDirectory(atPath: localShareJellyfinFolder.path)
-
-                for contentName in contents {
-                    let oldPath = localShareJellyfinFolder.appendingPathComponent(contentName)
-                    let newPath = applicationSupportJellyfinFolder.appendingPathComponent(contentName)
-                    try FileManager.default.moveItem(atPath: oldPath.path,
-                                                     toPath: newPath.path)
-                }
-
-                try FileManager.default.removeItem(atPath: localShareJellyfinFolder.path)
-            } catch {
-                present(alert: "Jellyfin Server was unable to properly migrate old directories.")
-            }
-        }
-
         if !directoryExists(path: applicationSupportJellyfinFolder.path) {
             do {
                 try FileManager.default.createDirectory(atPath: applicationSupportJellyfinFolder.path,
                                                         withIntermediateDirectories: true)
             } catch {
                 present(alert: "Jellyfin Server was unable to properly create necessary directories.")
+            }
+            // Old contents were stored in ~/.local/share
+            // Move to ~/Library/Application Support/Jellyfin
+            if directoryExists(path: localShareJellyfinFolder.path) {
+                do {
+                    let contents = try FileManager.default.contentsOfDirectory(atPath: localShareJellyfinFolder.path)
+
+                    for contentName in contents {
+                        let oldPath = localShareJellyfinFolder.appendingPathComponent(contentName)
+                        let newPath = applicationSupportJellyfinFolder.appendingPathComponent(contentName)
+                        try FileManager.default.moveItem(atPath: oldPath.path,
+                                                         toPath: newPath.path)
+                    }
+
+                    try FileManager.default.removeItem(atPath: localShareJellyfinFolder.path)
+                } catch {
+                    present(alert: "Jellyfin Server was unable to properly migrate old directories.")
+                }
             }
         }
     }


### PR DESCRIPTION
We cannot just naively move the database folder because database will store absolute path to the datadir. Just use that instead of moving folders.

Fixes #71 