### PR TITLE
Add new "Launch App" status bar menu item to launch the native player

### DIFF
--- a/Jellyfin Server/AppDelegate.swift
+++ b/Jellyfin Server/AppDelegate.swift
@@ -66,6 +66,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let menu = NSMenu()
 
         menu.addItem(withTitle: "Launch", action: #selector(launchWebUI), keyEquivalent: "l")
+
+        if (isNativeClientInstalled()) {
+            menu.addItem(withTitle: "Launch App", action: #selector(launchNativeApp), keyEquivalent: "a")
+        }
+
         menu.addItem(withTitle: "Show Logs", action: #selector(showLogs), keyEquivalent: "d")
         menu.addItem(withTitle: "Restart", action: #selector(restart), keyEquivalent: "r")
         menu.addItem(NSMenuItem.separator())
@@ -77,6 +82,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func launchWebUI() {
         ActionManager.launchWebUI()
+    }
+
+    @objc private func launchNativeApp() {
+        NSWorkspace.shared.openApplication(at: nativePlayerURL!, configuration: NSWorkspace.OpenConfiguration())
     }
 
     @objc private func showLogs() {

--- a/Jellyfin Server/Helpers.swift
+++ b/Jellyfin Server/Helpers.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Cocoa
 
 func isRunningFromApplicationFolder() -> Bool {
     let bundlePath = Bundle.main.bundlePath
@@ -35,6 +36,9 @@ func getLaunchAgentPlist() -> String {
 """
     return template
 }
+
+let nativePlayerBundleId: String = "tv.jellyfin.player"
+let nativePlayerURL: URL? = NSWorkspace.shared.urlForApplication(withBundleIdentifier: nativePlayerBundleId)
 
 let localShareJellyfinFolder: URL = FileManager.default.homeDirectoryForCurrentUser
     .appendingPathComponent(".local/share/jellyfin")
@@ -89,4 +93,8 @@ func getJellyfinNetworkConfig() -> (port: String, proto: String, subPath:String)
     } else {
         return (httpPort, "http", subPath)
     }
+}
+
+func isNativeClientInstalled() -> Bool {
+    return nativePlayerURL != nil
 }


### PR DESCRIPTION
This change modifies the status bar application. When building the status bar, the application now checks to see if the native Jellyfin Media Player is installed. If so, it adds an additional menu item to launch the app instead of the web UI.

| Before / when Media Player NOT installed | After when Media Player is installed |
| --- | --- |
|![Screenshot 2025-04-05 at 9 03 05 PM](https://github.com/user-attachments/assets/daa60e5d-33d7-4807-a598-9ab6598a3666)|![Screenshot 2025-04-05 at 8 58 48 PM](https://github.com/user-attachments/assets/41ad0772-b8eb-4d7b-a9c7-3a6de7d8ca9d)|
